### PR TITLE
Fix confirmation message display for "approve refund only"

### DIFF
--- a/ecommerce/templates/oscar/dashboard/partials/refund_action_modal.html
+++ b/ecommerce/templates/oscar/dashboard/partials/refund_action_modal.html
@@ -10,7 +10,7 @@
       <div class="modal-body confirm-approve">
         {% trans "Are you sure you want to issue a full refund and revoke student's enrollment?" %}
       </div>
-      <div class="modal-body confirm-refund_payment_only">
+      <div class="modal-body confirm-approve_payment_only">
         {% trans "Are you sure you want to issue a full refund without revoking student's enrollment?" %}
       </div>
       <div class="modal-body confirm-deny">


### PR DESCRIPTION
**Ticket LInk:** https://edlyio.atlassian.net/browse/EDE-376

**Description:**
Error: Missing confirmation message for "approve refund only" option. 

![image](https://user-images.githubusercontent.com/42185078/79982111-3588d000-84bf-11ea-962d-a9276f197a90.png)
